### PR TITLE
Add support for Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@ ENV PYTHON_VERSION_27 2.7.16
 ENV PYTHON_VERSION_35 3.5.7
 ENV PYTHON_VERSION_36 3.6.8
 ENV PYTHON_VERSION_37 3.7.3
+ENV PYTHON_VERSION_38 3.8.0
 ENV PYPY_VERSION_35 pypy3.5-7.0.0
 ENV CONDA_VERSION 4.6.14
 LABEL python.version_27=$PYTHON_VERSION_27
 LABEL python.version_35=$PYTHON_VERSION_35
 LABEL python.version_36=$PYTHON_VERSION_36
 LABEL python.version_37=$PYTHON_VERSION_37
+LABEL python.version_38=$PYTHON_VERSION_38
 LABEL pypy.version_35=$PYPY_VERSION_35
 LABEL conda.version=$CONDA_VERSION
 
@@ -160,12 +162,14 @@ ENV PATH /home/docs/.pyenv/shims:$PATH:/home/docs/.pyenv/bin
 
 # Install supported Python versions
 RUN pyenv install $PYTHON_VERSION_27 && \
+    pyenv install $PYTHON_VERSION_38 && \
     pyenv install $PYTHON_VERSION_37 && \
     pyenv install $PYTHON_VERSION_35 && \
     pyenv install $PYTHON_VERSION_36 && \
     pyenv install $PYPY_VERSION_35 && \
     pyenv global \
         $PYTHON_VERSION_27 \
+        $PYTHON_VERSION_38 \
         $PYTHON_VERSION_37 \
         $PYTHON_VERSION_36 \
         $PYTHON_VERSION_35 \
@@ -174,6 +178,12 @@ RUN pyenv install $PYTHON_VERSION_27 && \
 WORKDIR /tmp
 
 RUN pyenv local $PYTHON_VERSION_27 && \
+    pyenv exec pip install --no-cache-dir -U pip && \
+    pyenv exec pip install --no-cache-dir -U setuptools && \
+    pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
+    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
+
+RUN pyenv local $PYTHON_VERSION_38 && \
     pyenv exec pip install --no-cache-dir -U pip && \
     pyenv exec pip install --no-cache-dir -U setuptools && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ RUN pyenv local $PYTHON_VERSION_27 && \
 RUN pyenv local $PYTHON_VERSION_38 && \
     pyenv exec pip install --no-cache-dir -U pip && \
     pyenv exec pip install --no-cache-dir -U setuptools && \
-    pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
+    pyenv exec pip install --no-cache-dir --only-binary numpy numpy && \
     pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv
 
 RUN pyenv local $PYTHON_VERSION_37 && \

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ repository:
     This is the **latest** default image used for documentation builds and supported by Read the Docs.
 
 `readthedocs/build:6.0rc1`
-    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7 and PyPy3.5-7.0.0.
+    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     For internal development **testing** only, not available for public usage yet.
 
 .. _readthedocs/build: https://hub.docker.com/r/readthedocs/build/


### PR DESCRIPTION
I think we can create a 6.0rc1 release with support for Python 3.8 and start testing it with projects where users request for this feature.