### PR TITLE
Upgrade readme with new docker images

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,32 +41,8 @@ Releases
 --------
 
 These images are all built from our `automated Docker Hub repository`_. The
-automated build rules include pattern matching on Git tags. Here is how the
-images are currently tagged:
-
-build:latest
-    This is the latest supported release. Currently, this is ``3.0``.
-
-build:stable
-    This is the previously supported release. Currently, this is ``2.0``.
-
-build:4.0rc1
-    This is the next image being released, it will go through a testing cycle
-    before being considered a full release however. It is only a release
-    candidate currently, and is not useable on Read the Docs until full release.
-    This is the version built from ``master`` currently.
-
-build:3.0
-    From any tag matching ``3.0[0-9.]*``. These tags should only represent
-    commits to the ``releases/3.x`` branch.
-
-build:2.0
-    From any tag matching ``2.0[0-9.]*``. These tags should only represent
-    commits to the ``releases/2.x`` branch.
-
-build:1.0
-    From the ``1.0`` tag. These tags should only represent commits to the
-    ``releases/1.x`` branch.
+automated build rules include pattern matching on Git tags. The current tags
+are defined in the :doc:`README`.
 
 We follow `semantic versioning`_, but drop the bug fix level version number for
 our images, as this level of granularity is not important for any application of

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,8 @@ repository:
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     This is the **latest** default image used for documentation builds and supported by Read the Docs.
 
-`readthedocs/build:testing`
+`readthedocs/build:7.0`
+    ``testing``
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     For internal development **testing** only, not available for public usage yet.
 

--- a/README.rst
+++ b/README.rst
@@ -21,16 +21,20 @@ repository:
     Ubuntu 16.04 based image.
 
 `readthedocs/build:4.0`
-    ``stable``
+    **Deprecated**
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7.
-    This is the **stable** image supported by Read the Docs.
 
 `readthedocs/build:5.0`
-    ``latest``
+    ``stable``
     Ubuntu 18.04 supporting Python 2.7, 3.6, 3.7 and pypy3.5-7.0.0.
+    This is the **stable** image supported by Read the Docs.
+
+`readthedocs/build:6.0`
+    ``latest``
+    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     This is the **latest** default image used for documentation builds and supported by Read the Docs.
 
-`readthedocs/build:6.0rc1`
+`readthedocs/build:testing`
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     For internal development **testing** only, not available for public usage yet.
 


### PR DESCRIPTION
I would like to release new docker images soon.

These PRs have the code changes needed:

- https://github.com/readthedocs/readthedocs.org/pull/6654
- https://github.com/readthedocs/readthedocs.org/pull/6653
- https://github.com/readthedocs/readthedocs-ops/pull/646