### PR TITLE
Remove `LABEL version` from Dockerfile and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,20 +46,17 @@ are defined in the :doc:`README`.
 
 We follow `semantic versioning`_, but drop the bug fix level version number for
 our images, as this level of granularity is not important for any application of
-these images. Each release is tagged in Git, and the release version number is
-included in the Dockerfile version label (``LABEL version="2.0"``).
+these images.
 
 Releases should be merged into one of the ``releases/`` branches, for instance
-``releases/2.x``. The version label in the Dockerfile should be updated to the
-next version in the series, following semver rules. This commit should then also
-be tagged using the new version number.
+``releases/2.x``. This commit should then also be tagged using the new version number.
 
-If the version number in the Dockerfile was ``2.0.1`` before, and you implement
+If the version number was ``2.0.1`` before, and you implement
 a bug fix to the image, the new image will be ``2.0.2``. The output image from
 Docker Hub will still be ``2.0`` however. If a new feature is introduced, the
-new version tagged and in the Dockerfile will be ``2.1``.
+new version tagged will be ``2.1``.
 
-We don't care about bug fix version numbers here, as RTD will only ever have one
+We don't care about bug fix version numbers here, as Read the Docs will only ever have one
 main ``2.x`` image at a time. There is no need for us to run multiple bug fix
 versions at the same time.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 # Read the Docs - Environment base
 FROM ubuntu:18.04
 LABEL mantainer="Read the Docs <support@readthedocs.com>"
-LABEL version="5.0.0"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV APPDIR /app


### PR DESCRIPTION
Since this is at the top of the Dockerfile this avoid us to share layers between different docker images even if the image share most of it.