### PR TITLE
Prefix all of our variables with `RTD_` to avoid issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,29 +8,26 @@ ENV APPDIR /app
 ENV LANG C.UTF-8
 
 # Versions, and expose labels for external usage
-ENV PYTHON_VERSION_27 2.7.16
-ENV PYTHON_VERSION_35 3.5.7
-ENV PYTHON_VERSION_36 3.6.8
-ENV PYTHON_VERSION_37 3.7.3
-ENV PYTHON_VERSION_38 3.8.0
-ENV PYPY_VERSION_35 pypy3.5-7.0.0
+ENV RTD_PYTHON_VERSION_27 2.7.16
+ENV RTD_PYTHON_VERSION_35 3.5.7
+ENV RTD_PYTHON_VERSION_36 3.6.8
+ENV RTD_PYTHON_VERSION_37 3.7.3
+ENV RTD_PYTHON_VERSION_38 3.8.0
+ENV RTD_PYPY_VERSION_35 pypy3.5-7.0.0
 
 # Note: 4.7.12.1 drastically increases memory usage
-ENV CONDA_VERSION 4.6.14
+ENV RTD_CONDA_VERSION 4.6.14
 
-# Use _PIP_VERSION (with starting _) because of a bug in Pip
-# https://github.com/pypa/pip/issues/4528
-ENV _PIP_VERSION 20.0.1
-
-ENV SETUPTOOLS_VERSION 45.1.0
-ENV VIRTUALENV_VERSION 16.7.9
-LABEL python.version_27=$PYTHON_VERSION_27
-LABEL python.version_35=$PYTHON_VERSION_35
-LABEL python.version_36=$PYTHON_VERSION_36
-LABEL python.version_37=$PYTHON_VERSION_37
-LABEL python.version_38=$PYTHON_VERSION_38
-LABEL pypy.version_35=$PYPY_VERSION_35
-LABEL conda.version=$CONDA_VERSION
+ENV RTD_PIP_VERSION 20.0.1
+ENV RTD_SETUPTOOLS_VERSION 45.1.0
+ENV RTD_VIRTUALENV_VERSION 16.7.9
+LABEL python.version_27=$RTD_PYTHON_VERSION_27
+LABEL python.version_35=$RTD_PYTHON_VERSION_35
+LABEL python.version_36=$RTD_PYTHON_VERSION_36
+LABEL python.version_37=$RTD_PYTHON_VERSION_37
+LABEL python.version_38=$RTD_PYTHON_VERSION_38
+LABEL pypy.version_35=$RTD_PYPY_VERSION_35
+LABEL conda.version=$RTD_CONDA_VERSION
 
 # System dependencies
 RUN apt-get -y update
@@ -144,7 +141,7 @@ RUN apt-get -y install \
       python-pip \
  && pip install -U \
       auxlib \
-      virtualenv==$VIRTUALENV_VERSION
+      virtualenv==$RTD_VIRTUALENV_VERSION
 
 # sphinx-js dependencies: jsdoc and typedoc (TypeScript support)
 RUN apt-get -y install \
@@ -162,10 +159,10 @@ USER docs
 WORKDIR /home/docs
 
 # Install Conda
-RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh
-RUN bash Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh -b -p /home/docs/.conda/
+RUN curl -O https://repo.continuum.io/miniconda/Miniconda2-${RTD_CONDA_VERSION}-Linux-x86_64.sh
+RUN bash Miniconda2-${RTD_CONDA_VERSION}-Linux-x86_64.sh -b -p /home/docs/.conda/
 ENV PATH $PATH:/home/docs/.conda/bin
-RUN rm -f Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh
+RUN rm -f Miniconda2-${RTD_CONDA_VERSION}-Linux-x86_64.sh
 
 # Install pyenv
 RUN wget https://github.com/pyenv/pyenv/archive/master.zip
@@ -176,57 +173,57 @@ ENV PYENV_ROOT /home/docs/.pyenv
 ENV PATH /home/docs/.pyenv/shims:$PATH:/home/docs/.pyenv/bin
 
 # Install supported Python versions
-RUN pyenv install $PYTHON_VERSION_27 && \
-    pyenv install $PYTHON_VERSION_38 && \
-    pyenv install $PYTHON_VERSION_37 && \
-    pyenv install $PYTHON_VERSION_35 && \
-    pyenv install $PYTHON_VERSION_36 && \
-    pyenv install $PYPY_VERSION_35 && \
+RUN pyenv install $RTD_PYTHON_VERSION_27 && \
+    pyenv install $RTD_PYTHON_VERSION_38 && \
+    pyenv install $RTD_PYTHON_VERSION_37 && \
+    pyenv install $RTD_PYTHON_VERSION_35 && \
+    pyenv install $RTD_PYTHON_VERSION_36 && \
+    pyenv install $RTD_PYPY_VERSION_35 && \
     pyenv global \
-        $PYTHON_VERSION_27 \
-        $PYTHON_VERSION_38 \
-        $PYTHON_VERSION_37 \
-        $PYTHON_VERSION_36 \
-        $PYTHON_VERSION_35 \
-        $PYPY_VERSION_35
+        $RTD_PYTHON_VERSION_27 \
+        $RTD_PYTHON_VERSION_38 \
+        $RTD_PYTHON_VERSION_37 \
+        $RTD_PYTHON_VERSION_36 \
+        $RTD_PYTHON_VERSION_35 \
+        $RTD_PYPY_VERSION_35
 
 WORKDIR /tmp
 
-RUN pyenv local $PYTHON_VERSION_27 && \
+RUN pyenv local $RTD_PYTHON_VERSION_27 && \
     pyenv exec pip install --no-cache-dir -U pip==20.0.1 && \
     pyenv exec pip install --no-cache-dir -U setuptools==44.0.0 && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
     pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==16.7.9
 
-RUN pyenv local $PYTHON_VERSION_38 && \
-    pyenv exec pip install --no-cache-dir -U pip==$_PIP_VERSION && \
-    pyenv exec pip install --no-cache-dir -U setuptools==$SETUPTOOLS_VERSION && \
+RUN pyenv local $RTD_PYTHON_VERSION_38 && \
+    pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
     pyenv exec pip install --no-cache-dir --only-binary numpy numpy && \
-    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$VIRTUALENV_VERSION
+    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$RTD_VIRTUALENV_VERSION
 
-RUN pyenv local $PYTHON_VERSION_37 && \
-    pyenv exec pip install --no-cache-dir -U pip==$_PIP_VERSION && \
-    pyenv exec pip install --no-cache-dir -U setuptools==$SETUPTOOLS_VERSION && \
+RUN pyenv local $RTD_PYTHON_VERSION_37 && \
+    pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
-    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$VIRTUALENV_VERSION
+    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$RTD_VIRTUALENV_VERSION
 
-RUN pyenv local $PYTHON_VERSION_36 && \
-    pyenv exec pip install --no-cache-dir -U pip==$_PIP_VERSION && \
-    pyenv exec pip install --no-cache-dir -U setuptools==$SETUPTOOLS_VERSION && \
+RUN pyenv local $RTD_PYTHON_VERSION_36 && \
+    pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
-    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$VIRTUALENV_VERSION
+    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$RTD_VIRTUALENV_VERSION
 
-RUN pyenv local $PYTHON_VERSION_35 && \
-    pyenv exec pip install --no-cache-dir -U pip==$_PIP_VERSION && \
-    pyenv exec pip install --no-cache-dir -U setuptools==$SETUPTOOLS_VERSION && \
+RUN pyenv local $RTD_PYTHON_VERSION_35 && \
+    pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
     pyenv exec pip install --no-cache-dir --only-binary numpy,scipy numpy scipy && \
-    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$VIRTUALENV_VERSION
+    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$RTD_VIRTUALENV_VERSION
 
-RUN pyenv local $PYPY_VERSION_35 && \
+RUN pyenv local $RTD_PYPY_VERSION_35 && \
     pyenv exec python -m ensurepip && \
-    pyenv exec pip3 install --no-cache-dir -U pip==$_PIP_VERSION && \
-    pyenv exec pip install --no-cache-dir -U setuptools==$SETUPTOOLS_VERSION && \
-    pyenv exec pip install --no-cache-dir virtualenv==$VIRTUALENV_VERSION
+    pyenv exec pip3 install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
+    pyenv exec pip install --no-cache-dir virtualenv==$RTD_VIRTUALENV_VERSION
 
 WORKDIR /
 


### PR DESCRIPTION
PIP_VERSION and VIRTUALENV_VERSION are sensible variables that are read by pip and virtualenv respectively and we already have issues with them. So, to avoid this problem and future ones, we are prefixing all of our variables with `RTD_`.