### PR TITLE
Build python with `--enable-shared`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -186,7 +186,7 @@ RUN (export PYTHON_CONFIGURE_OPTS="--enable-shared"; \
         $RTD_PYTHON_VERSION_37 \
         $RTD_PYTHON_VERSION_36 \
         $RTD_PYTHON_VERSION_35 \
-        $RTD_PYPY_VERSION_35
+        $RTD_PYPY_VERSION_35)
 
 WORKDIR /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,8 @@ ENV PYENV_ROOT /home/docs/.pyenv
 ENV PATH /home/docs/.pyenv/shims:$PATH:/home/docs/.pyenv/bin
 
 # Install supported Python versions
-RUN pyenv install $RTD_PYTHON_VERSION_27 && \
+RUN (export PYTHON_CONFIGURE_OPTS="--enable-shared"; \
+    pyenv install $RTD_PYTHON_VERSION_27 && \
     pyenv install $RTD_PYTHON_VERSION_38 && \
     pyenv install $RTD_PYTHON_VERSION_37 && \
     pyenv install $RTD_PYTHON_VERSION_35 && \


### PR DESCRIPTION
This enables python packages that embed python into binaries to be documented with readthedocs.

This is in response to https://github.com/cocotb/cocotb/issues/1569, which we concluded was due to python being built without `--enable-shared`.

Taken from https://github.com/pyenv/pyenv/wiki#how-to-build-cpython-with---enable-shared