### PR TITLE
New version 8.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,10 +150,12 @@ ENV RTD_PYTHON_VERSION_35 3.5.7
 ENV RTD_PYTHON_VERSION_36 3.6.8
 ENV RTD_PYTHON_VERSION_37 3.7.3
 ENV RTD_PYTHON_VERSION_38 3.8.0
+ENV RTD_PYTHON_VERSION_39 3.9.0rc1
 ENV RTD_PYPY_VERSION_35 pypy3.5-7.0.0
 
 # Install supported Python versions
 RUN pyenv install $RTD_PYTHON_VERSION_27 && \
+    pyenv install $RTD_PYTHON_VERSION_39 && \
     pyenv install $RTD_PYTHON_VERSION_38 && \
     pyenv install $RTD_PYTHON_VERSION_37 && \
     pyenv install $RTD_PYTHON_VERSION_35 && \
@@ -161,6 +163,7 @@ RUN pyenv install $RTD_PYTHON_VERSION_27 && \
     pyenv install $RTD_PYPY_VERSION_35 && \
     pyenv global \
         $RTD_PYTHON_VERSION_27 \
+        $RTD_PYTHON_VERSION_39 \
         $RTD_PYTHON_VERSION_38 \
         $RTD_PYTHON_VERSION_37 \
         $RTD_PYTHON_VERSION_36 \
@@ -180,6 +183,12 @@ RUN pyenv local $RTD_PYTHON_VERSION_27 && \
 
 ENV RTD_PIP_VERSION 20.0.1
 ENV RTD_SETUPTOOLS_VERSION 45.1.0
+RUN pyenv local $RTD_PYTHON_VERSION_39 && \
+    pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
+    pyenv exec pip install --no-cache-dir --only-binary numpy numpy && \
+    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$RTD_VIRTUALENV_VERSION
+
 RUN pyenv local $RTD_PYTHON_VERSION_38 && \
     pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
     pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
@@ -232,6 +241,7 @@ LABEL python.version_35=$PYTHON_VERSION_35
 LABEL python.version_36=$PYTHON_VERSION_36
 LABEL python.version_37=$PYTHON_VERSION_37
 LABEL python.version_38=$PYTHON_VERSION_38
+LABEL python.version_38=$PYTHON_VERSION_39
 LABEL python.pip=$_PIP_VERSION
 LABEL python.setuptools=$SETUPTOOLS_VERSION
 LABEL python.virtualenv=$VIRTUALENV_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,9 @@ RUN apt-get -y install \
 
 # Install Python tools/libs
 ENV RTD_VIRTUALENV_VERSION 16.7.9
-RUN pip install -U \
+RUN apt-get -y install \
+      python-pip \
+ && pip install -U \
       auxlib \
       virtualenv==$RTD_VIRTUALENV_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,8 +116,8 @@ RUN apt-get -y install \
 # Install Python tools/libs
 ENV RTD_VIRTUALENV_VERSION 16.7.9
 RUN apt-get -y install \
-      python-pip \
- && pip install -U \
+      python3-pip \
+ && pip3 install -U \
       auxlib \
       virtualenv==$RTD_VIRTUALENV_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,9 +115,7 @@ RUN apt-get -y install \
 
 # Install Python tools/libs
 ENV RTD_VIRTUALENV_VERSION 16.7.9
-RUN apt-get -y install \
-      python-pip \
- && pip install -U \
+RUN pip install -U \
       auxlib \
       virtualenv==$RTD_VIRTUALENV_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Read the Docs - Environment base
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL mantainer="Read the Docs <support@readthedocs.com>"
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,9 +185,7 @@ ENV RTD_PIP_VERSION 20.0.1
 ENV RTD_SETUPTOOLS_VERSION 45.1.0
 RUN pyenv local $RTD_PYTHON_VERSION_39 && \
     pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
-    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
-    pyenv exec pip install --no-cache-dir --only-binary numpy numpy && \
-    pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$RTD_VIRTUALENV_VERSION
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION
 
 RUN pyenv local $RTD_PYTHON_VERSION_38 && \
     pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,8 +116,8 @@ RUN apt-get -y install \
 # Install Python tools/libs
 ENV RTD_VIRTUALENV_VERSION 16.7.9
 RUN apt-get -y install \
-      python3-pip \
- && pip3 install -U \
+      python3-pip && \
+      pip3 install -U \
       auxlib \
       virtualenv==$RTD_VIRTUALENV_VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,8 @@ ENV RTD_PIP_VERSION 20.0.1
 ENV RTD_SETUPTOOLS_VERSION 45.1.0
 RUN pyenv local $RTD_PYTHON_VERSION_39 && \
     pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
-    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION
+    pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
+    pyenv exec pip install --no-cache-dir virtualenv==$RTD_VIRTUALENV_VERSION
 
 RUN pyenv local $RTD_PYTHON_VERSION_38 && \
     pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \

--- a/README.rst
+++ b/README.rst
@@ -24,19 +24,19 @@ repository:
     **Deprecated**
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7.
 
-`readthedocs/build:5.0`
+`readthedocs/build:6.0`
     ``stable``
-    Ubuntu 18.04 supporting Python 2.7, 3.6, 3.7 and pypy3.5-7.0.0.
+    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     This is the **stable** image supported by Read the Docs.
 
-`readthedocs/build:6.0`
+`readthedocs/build:7.0`
     ``latest``
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     This is the **latest** default image used for documentation builds and supported by Read the Docs.
 
-`readthedocs/build:7.0`
+`readthedocs/build:8.0`
     ``testing``
-    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
+    Ubuntu 20.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8, 3.9.0rc1 and PyPy3.5-7.0.0.
     For internal development **testing** only, not available for public usage yet.
 
 .. _readthedocs/build: https://hub.docker.com/r/readthedocs/build/


### PR DESCRIPTION
- updates base image to Ubuntu 20.04 LTS
- adds Python 3.9.0rc1 (adding it now to avoid having to release 9.0 soon)
- updates readme to mention newer images (stable, latest, testing)
- do not install `numpy`, `pandas` and `matplotlib` in Python 3.9
  * this will be the first version of Python without these dependencies at "system package" level
  * we talked about removing them some time ago because it's not trust-able (not pinned version)
  * users using these package usually install them via `conda` (or regular `pip`)

Documentation to deploy this image into the servers once it's merged: https://docs.ops.verbthenouns.com/projects/community-ops/en/latest/deploying-docker-image.html