### PR TITLE
Use `.py` instead `.pyc` for Python3 virtualenv tests

### DIFF
--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -71,10 +71,10 @@ def test_command_versions_image_master(command, expected_output):
         ('python3.8 -c "import setuptools; print(setuptools.__version__)"', "45.2.0"),
         # virtualenv
         ('python2 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/2.7.18/lib/python2.7/site-packages/virtualenv/__init__.pyc'),
-        ('python3.5 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.5.10/lib/python3.5/site-packages/virtualenv/__init__.pyc'),
-        ('python3.6 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.6.12/lib/python3.6/site-packages/virtualenv/__init__.pyc'),
-        ('python3.7 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.7.9/lib/python3.7/site-packages/virtualenv/__init__.pyc'),
-        ('python3.8 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/virtualenv/__init__.pyc'),
+        ('python3.5 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.5.10/lib/python3.5/site-packages/virtualenv/__init__.py'),
+        ('python3.6 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.6.12/lib/python3.6/site-packages/virtualenv/__init__.py'),
+        ('python3.7 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.7.9/lib/python3.7/site-packages/virtualenv/__init__.py'),
+        ('python3.8 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/virtualenv/__init__.py'),
         # others
         ('node --version', 'v8.10.0'),
         ('npm --version', '3.5.2'),


### PR DESCRIPTION
This was already fixed in releases/7.x but it wasn't fixed in master.