### PR TITLE
Install poppler-utils (to get pdftoppm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,11 +105,14 @@ RUN apt-get -y install \
 # using Sphinx extension sphinxcontrib.rsvgconverter, see
 # https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter
 #
+# poppler-utils: pdftoppm for PDF -> PNG/JPEG/TIFF conversion
+#
 # swig: is required for different purposes
 # https://github.com/rtfd/readthedocs-docker-images/issues/15
 RUN apt-get -y install \
       imagemagick \
       librsvg2-bin \
+      poppler-utils \
       plantuml \
       swig
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,7 @@ RUN apt-get -y install \
 # imagemagick: is to support sphinx.ext.imgconverter
 # http://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html
 #
-# rsvg-convert: is for SVG -> PDF conversion
+# librsvg2-bin: rsvg-convert for SVG -> PDF conversion
 # using Sphinx extension sphinxcontrib.rsvgconverter, see
 # https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter
 #


### PR DESCRIPTION
Can you please install the package `poppler-utils`?

This provides the program `pdftoppm` for converting PDF files to bitmaps (like PNG, JPEG, TIFF, ...).

This conversion could theoretically also be done with `convert` (from ImageMagick, which is already installed), but this doesn't work, see #155.

Apart from that, my experiments so far have shown that `pdftoppm` produces better results.