### PR TITLE
Add support for Python 3.9 to 7.x image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHON_VERSION_35 3.5.10
 ENV PYTHON_VERSION_36 3.6.12
 ENV PYTHON_VERSION_37 3.7.9
 ENV PYTHON_VERSION_38 3.8.6
+ENV PYTHON_VERSION_39 3.9.1
 ENV PYPY_VERSION_35 pypy3.5-7.0.0
 # Note: 4.7.12.1 drastically increases memory usage
 ENV CONDA_VERSION 4.6.14
@@ -21,6 +22,7 @@ LABEL python.version_35=$PYTHON_VERSION_35
 LABEL python.version_36=$PYTHON_VERSION_36
 LABEL python.version_37=$PYTHON_VERSION_37
 LABEL python.version_38=$PYTHON_VERSION_38
+LABEL python.version_39=$PYTHON_VERSION_39
 LABEL pypy.version_35=$PYPY_VERSION_35
 LABEL conda.version=$CONDA_VERSION
 
@@ -175,6 +177,7 @@ ENV PATH /home/docs/.pyenv/shims:$PATH:/home/docs/.pyenv/bin
 
 # Install supported Python versions
 RUN pyenv install $PYTHON_VERSION_27 && \
+    pyenv install $PYTHON_VERSION_39 && \
     pyenv install $PYTHON_VERSION_38 && \
     pyenv install $PYTHON_VERSION_37 && \
     pyenv install $PYTHON_VERSION_35 && \
@@ -182,6 +185,7 @@ RUN pyenv install $PYTHON_VERSION_27 && \
     pyenv install $PYPY_VERSION_35 && \
     pyenv global \
         $PYTHON_VERSION_27 \
+        $PYTHON_VERSION_39 \
         $PYTHON_VERSION_38 \
         $PYTHON_VERSION_37 \
         $PYTHON_VERSION_36 \
@@ -198,6 +202,12 @@ RUN pyenv local $PYTHON_VERSION_27 && \
 
 ENV RTD_PIP_VERSION 20.0.2
 ENV RTD_SETUPTOOLS_VERSION 45.2.0
+RUN pyenv local $PYTHON_VERSION_39 && \
+  pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
+  pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \
+  pyenv exec pip install --no-cache-dir --only-binary numpy numpy && \
+  pyenv exec pip install --no-cache-dir pandas matplotlib virtualenv==$RTD_VIRTUALENV_VERSION
+
 RUN pyenv local $PYTHON_VERSION_38 && \
   pyenv exec pip install --no-cache-dir -U pip==$RTD_PIP_VERSION && \
   pyenv exec pip install --no-cache-dir -U setuptools==$RTD_SETUPTOOLS_VERSION && \

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -56,6 +56,7 @@ def test_command_versions_image_master(command, expected_output):
         ('python3.6 --version', 'Python 3.6.12'),
         ('python3.7 --version', 'Python 3.7.9'),
         ('python3.8 --version', 'Python 3.8.6'),
+        ('python3.9 --version', 'Python 3.9.1'),
         ('pypy3.5 --version', 'Python 3.5.3 (928a4f70d3de7d17449456946154c5da6e600162, Feb 09 2019, 11:50:43)\n[PyPy 7.0.0 with GCC 8.2.0]'),
         # pip
         ('python2 -m pip --version', "pip 20.0.2 from /home/docs/.pyenv/versions/2.7.18/lib/python2.7/site-packages/pip (python 2.7)"),
@@ -63,18 +64,21 @@ def test_command_versions_image_master(command, expected_output):
         ('python3.6 -m pip --version', "pip 20.0.2 from /home/docs/.pyenv/versions/3.6.12/lib/python3.6/site-packages/pip (python 3.6)"),
         ('python3.7 -m pip --version', "pip 20.0.2 from /home/docs/.pyenv/versions/3.7.9/lib/python3.7/site-packages/pip (python 3.7)"),
         ('python3.8 -m pip --version', "pip 20.0.2 from /home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/pip (python 3.8)"),
+        ('python3.9 -m pip --version', "pip 20.0.2 from /home/docs/.pyenv/versions/3.9.1/lib/python3.9/site-packages/pip (python 3.9)"),
         # setuptools
         ('python2 -c "import setuptools; print(setuptools.__version__)"', "44.0.0"),
         ('python3.5 -c "import setuptools; print(setuptools.__version__)"', "45.2.0"),
         ('python3.6 -c "import setuptools; print(setuptools.__version__)"', "45.2.0"),
         ('python3.7 -c "import setuptools; print(setuptools.__version__)"', "45.2.0"),
         ('python3.8 -c "import setuptools; print(setuptools.__version__)"', "45.2.0"),
+        ('python3.9 -c "import setuptools; print(setuptools.__version__)"', "45.2.0"),
         # virtualenv
         ('python2 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/2.7.18/lib/python2.7/site-packages/virtualenv/__init__.pyc'),
         ('python3.5 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.5.10/lib/python3.5/site-packages/virtualenv/__init__.py'),
         ('python3.6 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.6.12/lib/python3.6/site-packages/virtualenv/__init__.py'),
         ('python3.7 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.7.9/lib/python3.7/site-packages/virtualenv/__init__.py'),
         ('python3.8 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.8.6/lib/python3.8/site-packages/virtualenv/__init__.py'),
+        ('python3.9 -m virtualenv --version', 'virtualenv 20.0.7 from /home/docs/.pyenv/versions/3.9.1/lib/python3.9/site-packages/virtualenv/__init__.py'),
         # others
         ('node --version', 'v8.10.0'),
         ('npm --version', '3.5.2'),


### PR DESCRIPTION
Install Python 3.9 in our current "testing" (7.0) image so users can start
building their documentation with Python 3.9.

**NOTE:** I'm merging this into `release/7.x` branch, and they should be released as an update of the current "testing" image. These changes should be ported to `master` as well.

Requires: https://github.com/readthedocs/readthedocs.org/pull/7885
Closes #140 