### PR TITLE
Define pytest marks

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --strict-markers
 markers =
     image_master
     image_70

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    image_master
+    image_70
+    image_60
+    image_50


### PR DESCRIPTION
This is to avoid a WARNING,

```
tests/test_versions.py:7

  /home/travis/build/readthedocs/readthedocs-docker-images/tests/test_versions.py:7: PytestUnknownMarkWarning: Unknown pytest.mark.image_master - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html

    @pytest.mark.image_master
```