### PR TITLE
Add libkrb5-dev to build gssapi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get -y install \
       libgraphviz-dev \
       libjpeg8-dev \
       libjpeg-dev \
+      libkrb5-dev \
       liblcms2-dev \
       libmysqlclient-dev \
       libpq-dev \


### PR DESCRIPTION
The [gssapi](https://pypi.org/project/gssapi/) python package requires the krb5 headers to be present.