### PR TITLE
Fix README to better reflect reality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,19 +24,19 @@ repository:
     **Deprecated**
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7.
 
-`readthedocs/build:6.0`
+`readthedocs/build:5.0`
     ``stable``
-    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
+    Ubuntu 18.04 supporting Python 2.7, 3.6, 3.7 and pypy3.5-7.0.0.
     This is the **stable** image supported by Read the Docs.
 
-`readthedocs/build:7.0`
+`readthedocs/build:6.0`
     ``latest``
     Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     This is the **latest** default image used for documentation builds and supported by Read the Docs.
 
-`readthedocs/build:8.0`
+`readthedocs/build:7.0`
     ``testing``
-    Ubuntu 20.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8, 3.9.0rc1 and PyPy3.5-7.0.0.
+    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
     Available for public usage as **testing** image. You should expect some breaking changes here.
 
 .. _readthedocs/build: https://hub.docker.com/r/readthedocs/build/

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,14 @@ repository:
 
 .. _readthedocs/build: https://hub.docker.com/r/readthedocs/build/
 
+.. warning::
+
+   We are transitioning to a new way of building our Docker images, see
+   `the relevant design document <https://docs.readthedocs.io/en/stable/development/design/build-images.html>`_
+   for more information.
+   As a result, we will not update the current images
+   and will focus on implementing the new ones instead.
+
 Usage
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ repository:
 
 `readthedocs/build:7.0`
     ``testing``
-    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8 and PyPy3.5-7.0.0.
+    Ubuntu 18.04 supporting Python 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, and PyPy3.5-7.0.0.
     Available for public usage as **testing** image. You should expect some breaking changes here.
 
 .. _readthedocs/build: https://hub.docker.com/r/readthedocs/build/

--- a/README.rst
+++ b/README.rst
@@ -41,14 +41,6 @@ repository:
 
 .. _readthedocs/build: https://hub.docker.com/r/readthedocs/build/
 
-.. warning::
-
-   We are transitioning to a new way of building our Docker images, see
-   `the relevant design document <https://docs.readthedocs.io/en/stable/development/design/build-images.html>`_
-   for more information.
-   As a result, we will not update the current images
-   and will focus on implementing the new ones instead.
-
 Usage
 -----
 


### PR DESCRIPTION
Even though we updated the README in #137, we never updated the actual images on the service:

https://github.com/readthedocs/readthedocs.org/blob/75955e153d8a6e56d001008b6b3855455b5abeb0/readthedocs/settings/base.py#L501-L506

~Also, as @humitos mentioned in https://github.com/readthedocs/readthedocs-docker-images/pull/170#pullrequestreview-678638842 and other places, we don't intend to update these images anymore until we implement the new ones.~ (Edit: I toned this down, see reviews)

And finally, on #159 we added support for Python 3.9 in our `testing` image, but we didn't update the README to reflect that.