### PR TITLE
Ubuntu 22.04 LTS build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   tests:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.10
         environment:
           PIPENV_VENV_IN_PROJECT=1
           PIPENV_IGNORE_VIRTUALENVS=1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   tests:
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.8
         environment:
           PIPENV_VENV_IN_PROJECT=1
           PIPENV_IGNORE_VIRTUALENVS=1
@@ -19,7 +19,7 @@ jobs:
             pipenv install
       - run:
           name: Build Docker image
-          command: docker build -t readthedocs/build:ubuntu-20.04 .
+          command: docker build -t readthedocs/build:ubuntu-22.04 .
       - run:
           name: Run tests
           command: pipenv run pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Read the Docs - Environment base
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL mantainer="Read the Docs <support@readthedocs.com>"
-LABEL version="ubuntu-20.04-2021.09.23"
+LABEL version="ubuntu-22.04-2022.03.14"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
@@ -26,7 +26,7 @@ RUN apt-get -y install \
       graphviz-dev \
       libbz2-dev \
       libcairo2-dev \
-      libenchant1c2a \
+      libenchant-2-2 \
       libevent-dev \
       libffi-dev \
       libfreetype6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -112,7 +112,7 @@ USER docs
 WORKDIR /home/docs
 
 # Install asdf
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --depth 1 --branch v0.8.1
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --depth 1 --branch v0.9.0
 RUN echo ". /home/docs/.asdf/asdf.sh" >> /home/docs/.bashrc
 RUN echo ". /home/docs/.asdf/completions/asdf.bash" >> /home/docs/.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Read the Docs - Environment base
 FROM ubuntu:22.04
 LABEL mantainer="Read the Docs <support@readthedocs.com>"
-LABEL version="ubuntu-22.04-2022.03.14"
+LABEL version="ubuntu-22.04-2022.03.15"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8


### PR DESCRIPTION
Upgrade Ubuntu base image to 22.04 LTS for using them on users' builds.