### PR TITLE
asdf: update `asdf` and all its plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Read the Docs - Environment base
 FROM ubuntu:22.04
 LABEL mantainer="Read the Docs <support@readthedocs.com>"
-LABEL version="ubuntu-22.04-2022.03.15"
+LABEL version="ubuntu-22.04-2023.03.09"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
@@ -112,7 +112,7 @@ USER docs
 WORKDIR /home/docs
 
 # Install asdf
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --depth 1 --branch v0.9.0
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --depth 1 --branch v0.11.2
 RUN echo ". /home/docs/.asdf/asdf.sh" >> /home/docs/.bashrc
 RUN echo ". /home/docs/.asdf/completions/asdf.bash" >> /home/docs/.bashrc
 

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ repository:
     Ubuntu 20.04 supporting multiple versions of Python, PyPy, conda, mamba, nodejs, rust and go.
     Available for public usage as ``build.os: ubuntu-20.04``
 
+`readthedocs/build:ubuntu-22.04-YYYY.MM.DD`
+    Ubuntu 22.04 supporting multiple versions of Python, PyPy, conda, mamba, nodejs, rust and go.
+    Available for public usage as ``build.os: ubuntu-22.04``
+
 Note that these images only contains the basic dependencies:
 
 - ``asdf`` CLI manager to install the languages versions
@@ -31,11 +35,16 @@ Usage
 
 To use the pre-built images, you can pull from Docker Hub:
 
-    docker pull readthedocs/build:ubuntu-20.04-YYYY.MM.DD
+    docker pull readthedocs/build:ubuntu-22.04-YYYY.MM.DD
+
+.. note::
+
+   Docker has changed how the iamges are build and now ``buildx`` is required.
+   Read how to install it in your system at https://docs.docker.com/build/install-buildx/
 
 You can also compile these images locally:
 
-    docker build -t readthedocs/build:ubuntu-20.04-YYYY.MM.DD .
+    docker build -t readthedocs/build:ubuntu-22.04-YYYY.MM.DD .
 
 See `CONTRIBUTING`_ for more information on building and testing.
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -7,11 +7,11 @@ from .utils import run_command_in_container
 @pytest.mark.parametrize(
     'command,expected_output',
     [
-        ('asdf version', 'v0.9.0-9ee24a3'),
+        ('asdf version', 'v0.11.2-8eb11b8'),
         ('asdf plugin list', '\n'.join(['golang', 'nodejs', 'python', 'rust'])),
         ('git --version', 'git version 2.34.1'),
     ]
 )
-def test_command_versions_image_ubuntu20(command, expected_output):
+def test_command_versions_image_ubuntu22(command, expected_output):
     cmd_output = run_command_in_container(DOCKER_IMAGE, command)
     assert cmd_output == expected_output


### PR DESCRIPTION
This will allow us to be smarter about _when to reshim_.

With this update, it will be handled automatically by `asdf` and we won't require a custom chunk of code in our application:

https://github.com/readthedocs/readthedocs.org/blob/a5965129c61b9bcdff2f2098ff7ce7f8c093dc74/readthedocs/doc_builder/director.py#L373-L386

Currently, multi-lines commands that install something with `pip` and immediate after that, inside the multi-line command try to use the executable installed, fail because it's not automatically reshimed.

By reshiming at `asdf` level, this case will be solved.

Related: https://github.com/readthedocs/readthedocs.org/pull/9150#discussion_r882849790
Related: https://github.com/asdf-community/asdf-python/pull/136
Related: https://github.com/readthedocs/readthedocs.org/issues/10103