### PR TITLE
Backport: Add support for Ruby via `asdf` into Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Read the Docs - Environment base
 FROM ubuntu:20.04
 LABEL mantainer="Read the Docs <support@readthedocs.com>"
-LABEL version="ubuntu-20.04-2022.02.16"
+LABEL version="ubuntu-20.04-2024.01.29"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
@@ -112,7 +112,7 @@ USER docs
 WORKDIR /home/docs
 
 # Install asdf
-RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --depth 1 --branch v0.8.1
+RUN git clone https://github.com/asdf-vm/asdf.git ~/.asdf --depth 1 --branch v0.14.0
 RUN echo ". /home/docs/.asdf/asdf.sh" >> /home/docs/.bashrc
 RUN echo ". /home/docs/.asdf/completions/asdf.bash" >> /home/docs/.bashrc
 
@@ -124,11 +124,13 @@ RUN asdf plugin add python
 RUN asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
 RUN asdf plugin add rust https://github.com/code-lever/asdf-rust.git
 RUN asdf plugin add golang https://github.com/kennyp/asdf-golang.git
+RUN asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
 
 # Create directories for languages installations
 RUN mkdir -p /home/docs/.asdf/installs/python && \
     mkdir -p /home/docs/.asdf/installs/nodejs && \
     mkdir -p /home/docs/.asdf/installs/rust && \
-    mkdir -p /home/docs/.asdf/installs/golang
+    mkdir -p /home/docs/.asdf/installs/golang && \
+    mkdir -p /home/docs/.asdf/installs/ruby
 
 CMD ["/bin/bash"]

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -7,8 +7,8 @@ from .utils import run_command_in_container
 @pytest.mark.parametrize(
     'command,expected_output',
     [
-        ('asdf version', 'v0.8.1-a1ef92a'),
-        ('asdf plugin list', '\n'.join(['golang', 'nodejs', 'python', 'rust'])),
+        ('asdf version', 'v0.14.0-ccdd47d'),
+        ('asdf plugin list', '\n'.join(['golang', 'nodejs', 'python', 'ruby', 'rust'])),
         ('git --version', 'git version 2.25.1'),
     ]
 )


### PR DESCRIPTION
Backport 47cc2d45c9de85839e6c2cf2103ab599ea5d42e3 into Ubuntu 20.04 branch.

Related https://github.com/readthedocs/readthedocs.org/issues/10346