### PR TITLE
CircleCI: update `setup_remove_docker`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - run:
           name: Download "compile_version_upload_s3.sh" script
           command: |
@@ -85,7 +85,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
           docker_layer_caching: true
       - run:
           name: Setup


### PR DESCRIPTION
The image we were using is decprecated:
https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176